### PR TITLE
Updated registration info (only waiting list)

### DIFF
--- a/en/howto.html
+++ b/en/howto.html
@@ -20,31 +20,11 @@
 
   <h2><a name="register" id="register">Getting started</a></h2>
 
-  <p>To register for the game, go to <a href=
-  "/web/20070803081719/http://www.eressea.de/en/register.html">http://www.eressea.de/en/register.html</a>
-  and fill in the form. After registration, you will receive an email that
-  you must reply to in order to verify your registered email address. When
-  that is done, <b>just wait until your next turn, where you will receive
-  your first report</b>.</p>
-
-  <p>New factions are placed in virgin areas of the world, with only players
-  of the same age around them. Some players think it's a good idea to spend
-  the first few weeks registering over and over again until they get a
-  seemingly good position. It's not. It makes it impossible for the GM's to
-  create an adequate population density if too many factions drop out, and it
-  creates holes that are hard to fill. Don't let yourself be fooled by first
-  appearances: The starting positions are not chosen by an unintelligent
-  algorithm, but by someone with five years experience. If your first region
-  looks poor, chances are, there are plenty of resources around you, or a
-  good combination of other races that will help you in the long run. If the
-  region looks too good to be true, it sometimes isn't.</p>
-
-  <p>In order to help the GM's fill the gaps that early dropouts create, they
-  have added the option of starting in an already populated area. Select this
-  option on the registration form, and you will be placed among factions that
-  are up to 20 weeks old. You will of receive much better starting equipment,
-  and usually you will be placed among people who need someone just like
-  you.</p>
+  <p>In the past, each week new players were added in new regions to the
+  expanding game world. This is no longer the case. All currently running
+  games are closed and do not accept new players. You can however sing up
+  on a waiting list at <a href="http://www.eressea.de/en/register.php">www.eressea.de/en/register.php</a>.
+  If enough players have shown interest, a new game might happen.</p>
 
   <h2><a name="requirements" id="requirements">System requirements</a></h2>
 
@@ -58,20 +38,20 @@
   <p>Most likely, though, you will want something more visual. There are some
   wonderful graphical clients available to play Eressea with, like Magellan
   or EMap, as well as secondary tools for statistics, order preprocessing or
-  mapmaking. All of these can be found at <a href=
-  "/web/20070803081719/http://www.eressea.de/de/downloads.shtml">http://www.eressea.de/de/downloads.shtml</a>
-  and best of all, they are all free, written by players for players.</p>
+  mapmaking. All of these can be found via the game's web page and best of
+  all, they are all free, written by players for players.</p>
 
   <h2><a name="sending" id="sending">Sending in your orders</a></h2>
 
   <p>Once you've written your orders, you must send them to the game server.
-  They must be sent to <a href=
-  "mailto:eressea-server@eressea.kn-bremen.de">eressea-server@eressea.kn-bremen.de</a>
-  with the subject ERESSEA ORDERS in order to be recognized and processed. If
-  you have already sent in orders, and find that you want to make changes,
-  send in a second set of orders; they will override the old ones. A lot of
-  players send in preliminary orders early in the week, and another set later
-  in the week, when diplomacy with other players has made changes necessary.
+  They must be sent to <a href="mailto:eressea-server@eressea.kn-bremen.de">eressea-server@eressea.kn-bremen.de</a>
+  with the subject ERESSEA X ORDERS in order to be recognized and processed, 
+  where you have substitute X with the number of your game. So for Eressea 2
+  the subject would be ERESSEA 2 ORDERS. If you have already sent in orders,
+  and find that you want to make changes, send in a second set of orders; they
+  will override the old ones. A lot of players send in preliminary orders
+  early in the week, and another set later in the week, when diplomacy with
+  other players has made changes necessary.
   Make sure your computer's clock is set correctly. The game server uses the
   time at which you send the orders to determine the latest orders, not the
   time of their arrival.</p>


### PR DESCRIPTION
links to tools are no longer working
updated subject for orders mail
I do not know why the links have a form of "/web/20070803081719/http://www.eressea.de/en/register.html" so I have cleared the "web/.../" part. They work on my computer. Also I hate the formatting with 80 characters per line. Can we drop that?
